### PR TITLE
Fix CWE-275 : Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,4 +1,7 @@
 name: Android CI
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Add permissions

Resolves https://github.com/CrustyApplesniffer/BatteryWidget/security/code-scanning/1
