### PR TITLE
Adds JDK setup and makes gradlew executable

### DIFF
--- a/.github/workflows/deploy-internal.yml
+++ b/.github/workflows/deploy-internal.yml
@@ -50,6 +50,15 @@ jobs:
           echo "new_version_code=$NEW_VERSION_CODE" >> $GITHUB_OUTPUT
           echo "NEW_VERSION_CODE=$NEW_VERSION_CODE" >> $GITHUB_ENV
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        
       - name: Build Android App Bundle
         run: |
           ./gradlew :app:bundleRelease


### PR DESCRIPTION
Configures the workflow to use JDK 17 and makes the gradlew executable. This ensures the Android build process has the necessary environment to run successfully.