### PR TITLE
Fixes keystore retrieval for Dependabot

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,15 @@ android {
                 ?: System.getenv("KEYSTORE_FILE")
                 ?: "debug.keystore"
 
-            storeFile = file(keystorePath)
+            val keystoreFile = file(keystorePath)
+            val isDependabot = System.getenv("GITHUB_ACTOR")?.contains("dependabot") == true
+
+            // Fallback to debug.keystore if main keystore doesn't exist (Dependabot case)
+            storeFile = if (!keystoreFile.exists() && isDependabot) {
+                file("debug.keystore")
+            } else {
+                keystoreFile
+            }
 
             storePassword =
                 getLocalProperty("keystore.password") ?:


### PR DESCRIPTION
Ensures the app falls back to the debug keystore when running in a Dependabot environment and the primary keystore is not found.

This prevents build failures in Dependabot pull requests when the main keystore isn't available.