### PR TITLE
Ensures debug keystore exists for CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -27,8 +27,25 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Restore keystore
+      - name: Ensure debug keystore exists
         run: |
+          # Créer debug.keystore s'il n'existe pas
+          if [ ! -f "debug.keystore" ]; then
+            keytool -genkeypair \
+              -alias androiddebugkey \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 10000 \
+              -keystore debug.keystore \
+              -storepass android \
+              -keypass android \
+              -dname "CN=Android Debug,O=Android,C=US" \
+              -noprompt
+          fi
+
+      - name: Restore production keystore
+        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+        run: |      
           if [ -n "${{ secrets.KEYSTORE_FILE }}" ]; then
             echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > app/keystore.jks
           fi


### PR DESCRIPTION
Addresses a potential issue where the debug keystore might be missing during CI builds.

This change generates a debug keystore if one does not already exist, allowing CI to proceed without manual intervention. Production keystore restoration is now conditional, preventing issues with dependabot.

Fixes missing debug keystore issue in CI.