### PR TITLE
Moves debug keystore to app directory

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -41,6 +41,7 @@ jobs:
               -keypass android \
               -dname "CN=Android Debug,O=Android,C=US" \
               -noprompt
+            mv debug.keystore app/
           fi
 
       - name: Restore production keystore


### PR DESCRIPTION
The debug keystore needs to be in the app directory. This change ensures that the debug keystore is located in the correct directory.