### PR TITLE
Exports debug keystore environment variables

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -42,6 +42,10 @@ jobs:
               -dname "CN=Android Debug,O=Android,C=US" \
               -noprompt
             mv debug.keystore app/
+            echo "KEYSTORE_FILE=keystore.jks" >> $GITHUB_ENV
+            echo "KEYSTORE_PASSWORD=android" >> $GITHUB_ENV
+            echo "KEY_ALIAS=androiddebugkey" >> $GITHUB_ENV
+            echo "KEY_PASSWORD=android" >> $GITHUB_ENV
           fi
 
       - name: Restore production keystore
@@ -53,10 +57,12 @@ jobs:
 
       - name: Export signing env variables
         run: |
-          echo "KEYSTORE_FILE=keystore.jks" >> $GITHUB_ENV
-          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+          if [ -n "${{ secrets.KEYSTORE_FILE }}" ]; then
+            echo "KEYSTORE_FILE=keystore.jks" >> $GITHUB_ENV
+            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
+            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+          fi
 
       - name: Assemble Release
         run: ./gradlew assembleRelease


### PR DESCRIPTION
Exports environment variables required for signing debug builds, ensuring consistency between local and CI builds.

Conditionally exports signing env variables for production builds based on the presence of the keystore file secret.