### PR TITLE
Ensures debug keystore creation in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -106,8 +106,30 @@ jobs:
       if: matrix.build-mode == 'manual'
       run: chmod +x ./gradlew
 
-    - name: Restore keystore
+    - name: Ensure debug keystore exists
       if: matrix.build-mode == 'manual'
+      run: |
+        # Créer debug.keystore s'il n'existe pas
+        if [ ! -f "debug.keystore" ]; then
+          keytool -genkeypair \
+            -alias androiddebugkey \
+            -keyalg RSA \
+            -keysize 2048 \
+            -validity 10000 \
+            -keystore debug.keystore \
+            -storepass android \
+            -keypass android \
+            -dname "CN=Android Debug,O=Android,C=US" \
+            -noprompt
+          mv debug.keystore app/
+          echo "KEYSTORE_FILE=keystore.jks" >> $GITHUB_ENV
+          echo "KEYSTORE_PASSWORD=android" >> $GITHUB_ENV
+          echo "KEY_ALIAS=androiddebugkey" >> $GITHUB_ENV
+          echo "KEY_PASSWORD=android" >> $GITHUB_ENV
+        fi
+
+    - name: Restore keystore
+      if: matrix.build-mode == 'manual' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       run: |
         if [ -n "${{ secrets.KEYSTORE_FILE }}" ]; then
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > app/keystore.jks


### PR DESCRIPTION
Addresses an issue where the debug keystore might be missing during CI builds, specifically in manual build mode.

This commit adds logic to check for the existence of `debug.keystore` and generates it if it's not found. This ensures consistent builds even when the keystore is not explicitly present in the repository. Also, prevent dependabot to create debug keystore.

Fixes missing debug keystore for CI builds.