### PR TITLE
Guards keystore variable export

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -138,10 +138,12 @@ jobs:
     - name: Export signing env variables
       if: matrix.build-mode == 'manual'
       run: |
-        echo "KEYSTORE_FILE=keystore.jks" >> $GITHUB_ENV
-        echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-        echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-        echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+        if [ -n "${{ secrets.KEYSTORE_FILE }}" ]; then
+          echo "KEYSTORE_FILE=keystore.jks" >> $GITHUB_ENV
+          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
+          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+        fi
 
     - name: Assemble Release
       if: matrix.build-mode == 'manual'


### PR DESCRIPTION
Ensures keystore environment variables are only exported if the keystore file secret is defined.

This prevents errors in environments where keystore signing is not required, addressing potential build failures due to missing keystore credentials.