### PR TITLE
Migrate Kotlin plugin to AGP-bundled compiler and remove version pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
- ignore:
-      # WARNING: Kotlin > 2.2.30 incompatible with CodeQL
-      # To be updated when CodeQL supports Kotlin 2.3+
-      # Issue: https://github.com/github/codeql/issues/XXXXX
-      # Expected re-evaluation date: 2026-04-01
-      # TEMPORARILY ignore Kotlin 2.3.x
-      - dependency-name: "org.jetbrains.kotlin:*"
-        versions: ["2.3.x"] 
-        until: 2026-04-01
+
       

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
 }
 
 // Kotlin-only approach to read local.properties
@@ -97,8 +98,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = "1.8"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
     }
 
     buildFeatures {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
 }


### PR DESCRIPTION
The Android Gradle Plugin now bundles the Kotlin compiler, so the standalone `org.jetbrains.kotlin.android` plugin declaration and its version pin in the root build file are no longer needed. Compiler options are updated to use the modern `kotlin { compilerOptions { } }` DSL. The dependabot ignore rule blocking Kotlin 2.3.x is also removed since CodeQL now supports Kotlin 2.3+.